### PR TITLE
Fix typo: conatiner -> container

### DIFF
--- a/src/LineChart/Container.elm
+++ b/src/LineChart/Container.elm
@@ -27,7 +27,7 @@ import Internal.Container as Container
     chartConfig : LineChart.Config Data Msg
     chartConfig =
       { ...
-      , conatiner = Container.default
+      , container = Container.default
       , ...
       }
 


### PR DESCRIPTION
Found another typo in the docs :slightly_smiling_face: 