### PR TITLE
fixed typo in msg name: Recieve -> Receive

### DIFF
--- a/examples/LotsOfData.elm
+++ b/examples/LotsOfData.elm
@@ -51,13 +51,13 @@ init =
 
 
 type Msg
-  = RecieveNumbers (List Float)
+  = ReceiveNumbers (List Float)
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
   case msg of
-    RecieveNumbers numbers ->
+    ReceiveNumbers numbers ->
       ( { model | data = List.indexedMap toData numbers }
       , Cmd.none
       )
@@ -71,7 +71,7 @@ toData index =
 getNumbers : Cmd Msg
 getNumbers =
   Random.list 1501 (Random.float 0 20)
-    |> Random.generate RecieveNumbers
+    |> Random.generate ReceiveNumbers
 
 
 

--- a/examples/Selection2.elm
+++ b/examples/Selection2.elm
@@ -87,7 +87,7 @@ getNumbers =
       Random.list 200 (Random.float 0 20)
   in
   Random.map3 (,,) genNumbers genNumbers genNumbers
-    |> Random.generate RecieveNumbers
+    |> Random.generate ReceiveNumbers
 
 
 
@@ -136,7 +136,7 @@ getSelectionStart hovered model =
 
 
 type Msg
-  = RecieveNumbers ( List Float, List Float, List Float )
+  = ReceiveNumbers ( List Float, List Float, List Float )
   -- Chart 1
   | Hold Coordinate.Point
   | Move Coordinate.Point
@@ -150,7 +150,7 @@ type Msg
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
   case msg of
-    RecieveNumbers numbers ->
+    ReceiveNumbers2 numbers ->
       model
         |> setData numbers
         |> addCmd Cmd.none


### PR DESCRIPTION
Fixes a small typo in two examples: Receive was mis-spelt as Recieve