### PR TITLE
Use `containerStyles` instead of `styles`

### DIFF
--- a/src/Internal/Junk.elm
+++ b/src/Internal/Junk.elm
@@ -209,7 +209,7 @@ hoverAt system x y styles view =
     containerStyles =
       standardStyles ++ posititonStyles ++ styles
   in
-  Html.div (List.map (\(p,v) -> Html.Attributes.style p v) styles) view
+  Html.div (List.map (\(p,v) -> Html.Attributes.style p v) containerStyles) view
 
 
 


### PR DESCRIPTION
According to the conversation in #59, we should probably be using `containerStyles` here.

Hopefully, this fixes #59