### PR TITLE
explain how to use custom colors

### DIFF
--- a/src/LineChart/Colors.elm
+++ b/src/LineChart/Colors.elm
@@ -5,6 +5,15 @@ module LineChart.Colors exposing
   )
 
 {-|
+This module defines some default colors palette that looks good "out of the box". If you need some custom
+colors, install the [color module from Aaron VonderHaar](https://package.elm-lang.org/packages/avh4/elm-color/latest/):
+`elm install avh4/elm-color`, then just built the color you need:
+
+    import Color
+    
+    myCustomColor = Color.rgb255 142 35 140
+    
+ 
 
 <img alt="Colors!" width="610" src="https://github.com/terezka/line-charts/blob/master/images/colors.png?raw=true"></src>
 


### PR DESCRIPTION
Context: I was about to NOT choose your lib because it _looks like_ we cannot use colors outside from your `Color` module (more exactly, I was about to fork your lib to include my custom colors). Just having this little text indicating you _can_ build your own colors would have helped me a lot!